### PR TITLE
Add codegen job to bors config

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
-status = ['style', 'clippy', 'cpp', 'unit-tests', 'udeps', 'e2e', 'vm-sysroot']
+status = ['style', 'clippy', 'cpp', 'unit-tests', 'udeps', 'e2e', 'vm-sysroot', 'codegen']
 delete-merged-branches = true
 timeout-sec = 1800


### PR DESCRIPTION
Since #311 CI checks that `src/frontend-engine/docs/openapi-gen.json` is up-to-date. Unfortunately,
I forgot add this job to Bors config. This PR fixes this mistake.
bors r+