### PR TITLE
Mark github workflows as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.github/workflows/*.yaml linguist-generated=true


### PR DESCRIPTION
They can confuse reviewer, because "foo\nbar\nbaz" is considered poor "code" style.