### PR TITLE
Improve AuthData config readability

### DIFF
--- a/k8s/jjs/templates/init.yaml
+++ b/k8s/jjs/templates/init.yaml
@@ -7,7 +7,7 @@ data:
   auth_data: |
     endpoint: http://apiserver:1779/
     auth:
-      token:
+      byToken:
         token: Dev::root
   setup: |
     set -e

--- a/k8s/jjs/templates/invoker.yaml
+++ b/k8s/jjs/templates/invoker.yaml
@@ -52,7 +52,7 @@ spec:
             - name: RUST_LOG
               value: info,invoker=debug,problem_loader=debug,puller=debug
             - name: JJS_AUTH_DATA_INLINE
-              value: '{"endpoint": "http://apiserver:1779/", "auth": {"token": {"token": "Dev::root"}}}'
+              value: '{"endpoint": "http://apiserver:1779/", "auth": {"byToken": {"token": "Dev::root"}}}'
           image: "{{ .Values.image.repositoryPrefix }}invoker:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext: 

--- a/src/cli/src/login.rs
+++ b/src/cli/src/login.rs
@@ -42,7 +42,7 @@ pub(crate) async fn exec(opt: &Opt) -> anyhow::Result<()> {
     println!("Veryfying credentials");
     let ad = client::AuthData {
         endpoint: endpoint.clone(),
-        auth: client::auth_data::AuthKind::LoginAndPassword(
+        auth: client::auth_data::AuthKind::ByLoginAndPassword(
             client::auth_data::AuthByLoginAndPassword {
                 login: username.clone(),
                 password: password.clone(),

--- a/src/client/src/auth_data.rs
+++ b/src/client/src/auth_data.rs
@@ -41,8 +41,8 @@ impl AuthData {
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum AuthKind {
-    LoginAndPassword(AuthByLoginAndPassword),
-    Token(AuthByToken),
+    ByLoginAndPassword(AuthByLoginAndPassword),
+    ByToken(AuthByToken),
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -49,8 +49,8 @@ async fn obtain_token(ad: AuthData) -> anyhow::Result<String> {
     let mut conf = openapi::client::ClientConfiguration::new();
     conf.set_base_url(&ad.endpoint);
     match ad.auth {
-        auth_data::AuthKind::Token(tok) => Ok(tok.token),
-        auth_data::AuthKind::LoginAndPassword(lp) => {
+        auth_data::AuthKind::ByToken(tok) => Ok(tok.token),
+        auth_data::AuthKind::ByLoginAndPassword(lp) => {
             let client = RawClient::new(conf);
             let auth = models::SimpleAuthParams::login()
                 .login(lp.login)


### PR DESCRIPTION
Double "token" word in the config may be confusing.
Rename AuthKind suboptions to "ByToken" and "ByLoginAndPassword" fixes this.

Signed-off-by: Pavel Kalugin <paul.kalug@gmail.com>
