### PR TITLE
Refactor dockerfiles

### DIFF
--- a/src/apiserver/Dockerfile
+++ b/src/apiserver/Dockerfile
@@ -4,4 +4,4 @@ RUN pip3 install -r /tmp/req.txt
 COPY . /app
 WORKDIR /app
 EXPOSE 1779
-ENTRYPOINT ["uvicorn", "main:app", "--port", "1779", "--host", "0.0.0.0"]
+ENTRYPOINT ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "1779"]

--- a/src/cli/Dockerfile
+++ b/src/cli/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 RUN apt-get update -y && apt-get install -y libssl-dev
-COPY cli /cli
+COPY cli /bin/cli
 ENV JJS_AUTH_DATA=/auth/authdata.yaml
 VOLUME ["/auth"]
-CMD ["/cli"]
+ENTRYPOINT ["cli"]

--- a/src/invoker/Dockerfile
+++ b/src/invoker/Dockerfile
@@ -2,5 +2,5 @@ FROM debian:stable-slim
 RUN apt-get update -y && apt-get install -y libssl-dev
 ENV JJS_DATA=/data
 ENV JJS_PATH=/no-such-jjs-path
-COPY invoker /invoker
-CMD ["/invoker"]
+COPY invoker /bin/invoker
+ENTRYPOINT ["invoker"]

--- a/src/ppc/Dockerfile
+++ b/src/ppc/Dockerfile
@@ -2,6 +2,6 @@ FROM debian:stable-slim
 # TODO: use rustls
 RUN apt-get update -y && apt-get install -y libssl-dev
 ENV JJS_AUTH_DATA=/auth/authdata.yaml JJS_PATH=/jtl
-COPY ppc /ppc
+COPY ppc /bin/ppc
 VOLUME ["/auth"]
-CMD ["/ppc"]
+ENTRYPOINT ["ppc"]


### PR DESCRIPTION
Split CMD to ENTRYPOINT and actual CMD
Put binaries on PATH (/bin instead of /)

Signed-off-by: Pavel Kalugin <paul.kalug@gmail.com>